### PR TITLE
Altered googlefonts example to use more idomatic Harlowe

### DIFF
--- a/googlefonts/harlowe/harlowe_googlefonts.md
+++ b/googlefonts/harlowe/harlowe_googlefonts.md
@@ -24,12 +24,8 @@ Harlowe: Google Fonts
 :: StoryStylesheet[stylesheet]
 @import url('https://fonts.googleapis.com/css?family=Roboto');
 
-.googleFont {
-	font-family: 'Roboto', sans-serif; 
-}
-
 :: Start
-<div class="googleFont">This text is styled by a Google Font</div>
+(font:"Roboto")[This text is styled by a Google Font]
 
 ```
 Download: <a href="harlowe_googlefonts_twee.txt" target="_blank">Twee Code</a>

--- a/googlefonts/harlowe/harlowe_googlefonts_example.html
+++ b/googlefonts/harlowe/harlowe_googlefonts_example.html
@@ -12,10 +12,7 @@
 <tw-story></tw-story>
 
 <tw-storydata name="Harlowe: Google Fonts" startnode="1" creator="Twine" creator-version="2.1.3" ifid="62375486-63D4-4960-88B9-49F289799ACD" format="Harlowe" format-version="2.0.1" options="" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">@import url('https://fonts.googleapis.com/css?family=Roboto');
-
-.googleFont {
-	font-family: 'Roboto', sans-serif; 
-}</style><script role="script" id="twine-user-script" type="text/twine-javascript"></script><tw-passagedata pid="1" name="Start" tags="" position="101,98">&lt;div class=&quot;googleFont&quot;&gt;This text is styled by a Google Font&lt;/div&gt;</tw-passagedata></tw-storydata>
+</style><script role="script" id="twine-user-script" type="text/twine-javascript"></script><tw-passagedata pid="1" name="Start" tags="" position="101,98">(font:"Roboto")[This text is styled by a Google Font]</tw-passagedata></tw-storydata>
 
 <script title="Twine engine code" data-main="harlowe">"use strict";function _defineProperty(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}function _toConsumableArray(e){if(Array.isArray(e)){for(var t=0,n=Array(e.length);t<e.length;t++)n[t]=e[t];return n}return Array.from(e)}var _slicedToArray=function(){function e(e,t){var n=[],r=!0,i=!1,o=void 0;try{for(var a,s=e[Symbol.iterator]();!(r=(a=s.next()).done)&&(n.push(a.value),!t||n.length!==t);r=!0);}catch(e){i=!0,o=e}finally{try{!r&&s.return&&s.return()}finally{if(i)throw o}}return n}return function(t,n){if(Array.isArray(t))return t;if(Symbol.iterator in Object(t))return e(t,n);throw new TypeError("Invalid attempt to destructure non-iterable instance")}}(),_typeof="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e};!function(){/**
  * @license almond 0.3.3 Copyright jQuery Foundation and other contributors.

--- a/googlefonts/harlowe/harlowe_googlefonts_twee.txt
+++ b/googlefonts/harlowe/harlowe_googlefonts_twee.txt
@@ -4,9 +4,5 @@ Harlowe: Google Fonts
 :: StoryStylesheet[stylesheet]
 @import url('https://fonts.googleapis.com/css?family=Roboto');
 
-.googleFont {
-	font-family: 'Roboto', sans-serif; 
-}
-
 :: Start
-<div class="googleFont">This text is styled by a Google Font</div>
+(font:"Roboto")[This text is styled by a Google Font]


### PR DESCRIPTION
While HTML is and always will be a valid Harlowe coding style, the (font:) macro allows fonts to be used without an intervening CSS class being created. This additionally allows the example to scale, as adding more Google fonts precludes adding more classes and DIVs.

Note: unlike the previous version, this does not have any "sans-serif" fallback family. However, I feel like the target audience mightn't necessarily understand font fallbacks very well anyway, and might erroneously include "sans-serif" as a fallback for serif Google fonts based off this.