### PR TITLE
Reworked the Harlowe modal example to be easier to call, and to use H…

### DIFF
--- a/modal/harlowe/harlowe_modal.md
+++ b/modal/harlowe/harlowe_modal.md
@@ -1,7 +1,7 @@
 # "Modal (Pop-up Window)": Harlowe (v2.0)
 
 ## Summary
-This example creates a re-usable modal window. It can be opened using the combination of *(link-repeat:)* and *(show:)* to 'show' the window and be 'closed' using *(link-repeat:)* with the *(replace:)* macro to change the content. CSS rules are used to style the window and create the effect of having content be darkeneded behind the 'shown' content.
+This example creates a re-usable modal window. It can be opened using the combination of *(link-repeat:)* and *(replace:)* to create the window in an existing hook, and be 'closed' using the same macros to remove the window. CSS rules are applied with *(css:)* to style the modal, and to change an enclosing hook into a "dimmer" which obscures the rest of the page.
 
 ## Live Example
 
@@ -18,60 +18,36 @@ Download: <a href="harlowe_modal_example.html" target="_blank">Live Example</a>
 :: StoryTitle
 Harlowe: Modal
 
-:: UserStylesheet[stylesheet]
-/* The Modal (background) */
-.modal {
-    display: block;
-    position: fixed; /* Stay in place */
-    z-index: 1; /* Sit on top */
-    left: 0;
-    top: 0;
-    width: 100%; /* Full width */
-    height: 100%; /* Full height */
-    overflow: auto; /* Enable scroll if needed */
-    background-color: rgb(0,0,0); /* Fallback color */
-    background-color: rgba(0,0,0,0.4); /* Black w/ opacity */
-}
+:: Header[header]
+|modalhooks>[]
 
-/* Modal Content/Box */
-.modal-content {
-    background-color: #fefefe;
-    margin: 15% auto; /* 15% from the top and centered */
-    padding: 20px;
-    border: 1px solid #888;
-    width: 80%; /* Could be more or less, depending on screen size */
-  	color: black; /* Make the text black */
-}
-
-/* The Close Button */
-.close {
-    float: right;
-    font-size: 28px;
-    font-weight: bold;
-}
-
-.close:hover,
-.close:focus {
-    color: black;
-    text-decoration: none;
-    cursor: pointer;
-}
-
+:: Modal code
+(replace: ?modalhooks)[{
+  (css:"
+	position: fixed;
+	display:block;
+	z-index: 1;
+	left: 0;
+	top: 0;
+	width: 100%; /* Full width */
+	height: 100%; /* Full height */
+	overflow: auto; /* Enable scroll if needed */
+	background-color: rgba(0,0,0,0.4);
+  ")[
+	(css:"
+	  display:block;
+	  margin: 15% auto;
+	  padding: 20px;
+	  width: 80%;
+	  border: 1px solid white;
+	")|modal>[
+	  (css:"float:right")+(link-repeat:"×")[(replace: ?modalhooks)[]]
+	]
+  ]
+}]
 
 :: Start
-{[
-	<div class="modal">
-  		<div class="modal-content">
-    		<span class="close">
-			{(link-repeat: "×")[(replace: ?modal)[] ]}
-			</span>
-    	Some text in the Modal..
-  		</div>
-	</div>
-](modal|}
-(link-repeat:"Open Modal!")[(show:?modal)]
-
-
+(link-repeat:"Open Modal!")[(display:"Modal code")(append:?modal)[Some text in the modal...]]
 ```
 
 Download: <a href="harlowe_modal_twee.txt" target="_blank">Twee Code</a>

--- a/modal/harlowe/harlowe_modal_example.html
+++ b/modal/harlowe/harlowe_modal_example.html
@@ -11,56 +11,29 @@
 
 <tw-story></tw-story>
 
-<tw-storydata name="Harlowe: Modal" startnode="1" creator="Twine" creator-version="2.1.3" ifid="B8C3E688-5B78-4BC2-B022-5CD783A4A12E" format="Harlowe" format-version="2.0.1" options="" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">/* The Modal (background) */
-.modal {
-    display: block;
-    position: fixed; /* Stay in place */
-    z-index: 1; /* Sit on top */
-    left: 0;
-    top: 0;
-    width: 100%; /* Full width */
-    height: 100%; /* Full height */
-    overflow: auto; /* Enable scroll if needed */
-    background-color: rgb(0,0,0); /* Fallback color */
-    background-color: rgba(0,0,0,0.4); /* Black w/ opacity */
-}
-
-/* Modal Content/Box */
-.modal-content {
-    background-color: #fefefe;
-    margin: 15% auto; /* 15% from the top and centered */
-    padding: 20px;
-    border: 1px solid #888;
-    width: 80%; /* Could be more or less, depending on screen size */
-  	color: black; /* Make the text black */
-}
-
-/* The Close Button */
-.close {
-    float: right;
-    font-size: 28px;
-    font-weight: bold;
-}
-
-.close:hover,
-.close:focus {
-    color: black;
-    text-decoration: none;
-    cursor: pointer;
-}
-
-</style><script role="script" id="twine-user-script" type="text/twine-javascript">
-</script><tw-passagedata pid="1" name="Start" tags="" position="200,99">{[
-	&lt;div class=&quot;modal&quot;&gt;
-  		&lt;div class=&quot;modal-content&quot;&gt;
-    		&lt;span class=&quot;close&quot;&gt;
-			{(link-repeat: &quot;&amp;times&quot;)[(replace: ?modal)[] ]}
-			&lt;/span&gt;
-    	Some text in the Modal..
-  		&lt;/div&gt;
-	&lt;/div&gt;
-](modal|}
-(link-repeat:&quot;Open Modal!&quot;)[(show:?modal)]</tw-passagedata></tw-storydata>
+<tw-storydata name="Harlowe: Modal" startnode="1" creator="Twine" creator-version="2.1.3" ifid="B8C3E688-5B78-4BC2-B022-5CD783A4A12E" format="Harlowe" format-version="2.0.1" options="" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css"></style><script role="script" id="twine-user-script" type="text/twine-javascript"></script><tw-passagedata pid="1" name="Start" tags="" position="819.5,439.5" size="100,100">(link-repeat:&quot;Open Modal!&quot;)[(display:&quot;Modal code&quot;)(append:?modal)[Some text in the modal...]]</tw-passagedata><tw-passagedata pid="2" name="Modal code" tags="" position="820,329.5" size="100,100">(replace: ?modalhooks)[{
+  (css:&quot;
+	position: fixed;
+	display:block;
+	z-index: 1;
+	left: 0;
+	top: 0;
+	width: 100%; /* Full width */
+	height: 100%; /* Full height */
+	overflow: auto; /* Enable scroll if needed */
+	background-color: rgba(0,0,0,0.4);
+  &quot;)[
+	(css:&quot;
+	  display:block;
+	  margin: 15% auto;
+	  padding: 20px;
+	  width: 80%;
+	  border: 1px solid white;
+	&quot;)|modal&gt;[
+	  (css:&quot;float:right&quot;)+(link-repeat:&quot;×&quot;)[(replace: ?modalhooks)[]]
+	]
+  ]
+}]</tw-passagedata><tw-passagedata pid="3" name="Header" tags="header" position="710,329.5" size="100,100">|modalhooks&gt;[]</tw-passagedata></tw-storydata>
 
 <script title="Twine engine code" data-main="harlowe">"use strict";function _defineProperty(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}function _toConsumableArray(e){if(Array.isArray(e)){for(var t=0,n=Array(e.length);t<e.length;t++)n[t]=e[t];return n}return Array.from(e)}var _slicedToArray=function(){function e(e,t){var n=[],r=!0,i=!1,o=void 0;try{for(var a,s=e[Symbol.iterator]();!(r=(a=s.next()).done)&&(n.push(a.value),!t||n.length!==t);r=!0);}catch(e){i=!0,o=e}finally{try{!r&&s.return&&s.return()}finally{if(i)throw o}}return n}return function(t,n){if(Array.isArray(t))return t;if(Symbol.iterator in Object(t))return e(t,n);throw new TypeError("Invalid attempt to destructure non-iterable instance")}}(),_typeof="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e};!function(){/**
  * @license almond 0.3.3 Copyright jQuery Foundation and other contributors.

--- a/modal/harlowe/harlowe_modal_twee.txt
+++ b/modal/harlowe/harlowe_modal_twee.txt
@@ -1,55 +1,33 @@
 :: StoryTitle
 Harlowe: Modal
 
-:: UserStylesheet[stylesheet]
-/* The Modal (background) */
-.modal {
-    display: block;
-    position: fixed; /* Stay in place */
-    z-index: 1; /* Sit on top */
-    left: 0;
-    top: 0;
-    width: 100%; /* Full width */
-    height: 100%; /* Full height */
-    overflow: auto; /* Enable scroll if needed */
-    background-color: rgb(0,0,0); /* Fallback color */
-    background-color: rgba(0,0,0,0.4); /* Black w/ opacity */
-}
+:: Header[header]
+|modalhooks>[]
 
-/* Modal Content/Box */
-.modal-content {
-    background-color: #fefefe;
-    margin: 15% auto; /* 15% from the top and centered */
-    padding: 20px;
-    border: 1px solid #888;
-    width: 80%; /* Could be more or less, depending on screen size */
-  	color: black; /* Make the text black */
-}
-
-/* The Close Button */
-.close {
-    float: right;
-    font-size: 28px;
-    font-weight: bold;
-}
-
-.close:hover,
-.close:focus {
-    color: black;
-    text-decoration: none;
-    cursor: pointer;
-}
-
+:: Modal code
+(replace: ?modalhooks)[{
+  (css:"
+	position: fixed;
+	display:block;
+	z-index: 1;
+	left: 0;
+	top: 0;
+	width: 100%; /* Full width */
+	height: 100%; /* Full height */
+	overflow: auto; /* Enable scroll if needed */
+	background-color: rgba(0,0,0,0.4);
+  ")[
+	(css:"
+	  display:block;
+	  margin: 15% auto;
+	  padding: 20px;
+	  width: 80%;
+	  border: 1px solid white;
+	")|modal>[
+	  (css:"float:right")+(link-repeat:"×")[(replace: ?modalhooks)[]]
+	]
+  ]
+}]
 
 :: Start
-{[
-	<div class="modal">
-  		<div class="modal-content">
-    		<span class="close">
-			{(link-repeat: "×")[(replace: ?modal)[] ]}
-			</span>
-    	Some text in the Modal..
-  		</div>
-	</div>
-](modal|}
-(link-repeat:"Open Modal!")[(show:?modal)]
+(link-repeat:"Open Modal!")[(display:"Modal code")(append:?modal)[Some text in the modal...]]


### PR DESCRIPTION
…arlowe idioms.

Advantages over the previous one:

 * Calling it can be done in one line, without any HTML wrappers included.

 * No stylesheet CSS used, so that the user's stylesheet is less cluttered with utility code.

 * The modal continues to use the colour scheme of the rest of the story, so that it isn't necessarily white-on-black.

 * As a personal preference, leaving the close X as a standard Harlowe link colour feels more correct to me, insofar as it denotes that it's clickable in a familiar way to the player.

Note: as far as I know, any browser that doesn't support CSS3 `rbga()` is also one that can't run Harlowe at all (i.e. IE <9)