### PR TITLE
Potentially better Harlowe implementation of Cycling Choices

### DIFF
--- a/cycling/harlowe/harlowe_cycling.md
+++ b/cycling/harlowe/harlowe_cycling.md
@@ -6,11 +6,11 @@
 
 "Cycling Choices" demostrates how to create a 'cycling' effect of different choices through clicking on them.
 
-The 'cycle' starts with the use of the [*(display:)*](https://twine2.neocities.org/#macro_display) macro and assumption of *$choicesCount* beginning at the number 0. It is then increased by one to the value 1 (the first location of [an array in Harlowe](https://twine2.neocities.org/#type_array)) and the position of *$choices* is shown based on this. 
+The 'cycle' starts with the use of the [*(display:)*](https://twine2.neocities.org/#macro_display) macro and the assumption that the 1st element in the *$choices* [Array](https://twine2.neocities.org/#type_array) is the currently selected choice.
 
-If the user clicks on the link (created through using the [*(link:)*](https://twine2.neocities.org/#macro_link) and *(display:)* macros) again, future 'cycles' test if *$choicesCount* increases beyond the number of values in the *$choices* array and resets it to 1. 
+If the user clicks on the link (created through using the [*(link:)*](https://twine2.neocities.org/#macro_link) then the *$choices* array is updated using the [*(rotated:)*](https://twine2.neocities.org/#macro_rotated) macro, this causes the current 1st element to be moved to the end of the array thus making the element that was previously 2nd to now be 1st.
 
-At the end of every 'cycle,' the currently selected value is stored in the variable *$cyclingResult* for future access and usage.
+At the end of every 'cycle,' the currently selected value is always the 1st element in the *$choices* array.
 
 ## Live Example
 
@@ -28,20 +28,20 @@ Download: <a href="harlowe_cycling_example.html" target="_blank">Live Example</a
 Cycling Choices in Harlowe
 
 :: Start
-Click options to cycle: (display: "Cycling")
+(set: $choices to (array: "First", "Second", "Third"))
+Click options to cycle: [(display: "Cycling")]<choice|
 [[Submit|Results]]
 
 :: Cycling
 {
-	(set: $choices to (array: "First", "Second", "Third") )
-	(if: $choicesCount >= $choices's length)[(set: $choicesCount to 1)]
-	(else:)[(set: $choicesCount to it + 1)]
-	(set: $cyclingResult to $choices's $choicesCount)
-	(link: (text: $choices's $choicesCount) )[(display: "Cycling")]
+	(link: (text: $choices's 1st) )[
+		(set: $choices to (rotated: -1, ...$choices))
+		(replace: ?choice)[(display: "Cycling")]
+	]
 }
 
 :: Results
-$cyclingResult
+Selected choice: (print: $choices's 1st)
 ```
 
 Download: <a href="harlowe_cycling_twee.txt" target="_blank">Twee Code</a>

--- a/cycling/harlowe/harlowe_cycling_example.html
+++ b/cycling/harlowe/harlowe_cycling_example.html
@@ -11,16 +11,14 @@
 
 <tw-story></tw-story>
 
-<tw-storydata name="Cycling Choices in Harlowe" startnode="1" creator="Twine" creator-version="2.1.3" ifid="0E300B36-B01D-48A2-9E23-02B1F1A21D1A" format="Harlowe" format-version="2.0.1" options="" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">
-</style><script role="script" id="twine-user-script" type="text/twine-javascript">
-</script><tw-passagedata pid="1" name="Start" tags="" position="94,97">Click options to cycle: (display: &quot;Cycling&quot;)
-[[Submit|Results]]</tw-passagedata><tw-passagedata pid="2" name="Cycling" tags="" position="302,100">{
-	(set: $choices to (array: &quot;First&quot;, &quot;Second&quot;, &quot;Third&quot;) )
-	(if: $choicesCount &gt;= $choices&#x27;s length)[(set: $choicesCount to 1)]
-	(else:)[(set: $choicesCount to it + 1)]
-	(set: $cyclingResult to $choices&#x27;s $choicesCount)
-	(link: (text: $choices&#x27;s $choicesCount) )[(display: &quot;Cycling&quot;)]
-}</tw-passagedata><tw-passagedata pid="3" name="Results" tags="" position="99,255">$cyclingResult</tw-passagedata></tw-storydata>
+<tw-storydata name="Cycling Choices in Harlowe" startnode="1" creator="Tweego" creator-version="1.2.0" ifid="567A9601-EFF7-4463-A632-C077821F3D96" zoom="1" format="Harlowe" format-version="2.0.1" options="" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css"></style><script role="script" id="twine-user-script" type="text/twine-javascript"></script><tw-passagedata pid="1" name="Start" tags="" position="100,100">(set: $choices to (array: &quot;First&quot;, &quot;Second&quot;, &quot;Third&quot;))
+Click options to cycle: [(display: &quot;Cycling&quot;)]&lt;choice|
+[[Submit|Results]]</tw-passagedata><tw-passagedata pid="2" name="Cycling" tags="" position="225,100">{
+	(link: (text: $choices&#39;s 1st) )[
+		(set: $choices to (rotated: -1, ...$choices))
+		(replace: ?choice)[(display: &quot;Cycling&quot;)]
+	]
+}</tw-passagedata><tw-passagedata pid="3" name="Results" tags="" position="350,100">Selected choice: (print: $choices&#39;s 1st)</tw-passagedata></tw-storydata>
 
 <script title="Twine engine code" data-main="harlowe">"use strict";function _defineProperty(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}function _toConsumableArray(e){if(Array.isArray(e)){for(var t=0,n=Array(e.length);t<e.length;t++)n[t]=e[t];return n}return Array.from(e)}var _slicedToArray=function(){function e(e,t){var n=[],r=!0,i=!1,o=void 0;try{for(var a,s=e[Symbol.iterator]();!(r=(a=s.next()).done)&&(n.push(a.value),!t||n.length!==t);r=!0);}catch(e){i=!0,o=e}finally{try{!r&&s.return&&s.return()}finally{if(i)throw o}}return n}return function(t,n){if(Array.isArray(t))return t;if(Symbol.iterator in Object(t))return e(t,n);throw new TypeError("Invalid attempt to destructure non-iterable instance")}}(),_typeof="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e};!function(){/**
  * @license almond 0.3.3 Copyright jQuery Foundation and other contributors.

--- a/cycling/harlowe/harlowe_cycling_twee.txt
+++ b/cycling/harlowe/harlowe_cycling_twee.txt
@@ -2,17 +2,18 @@
 Cycling Choices in Harlowe
 
 :: Start
-Click options to cycle: (display: "Cycling")
+(set: $choices to (array: "First", "Second", "Third"))
+Click options to cycle: [(display: "Cycling")]<choice|
 [[Submit|Results]]
+
 
 :: Cycling
 {
-	(set: $choices to (array: "First", "Second", "Third") )
-	(if: $choicesCount >= $choices's length)[(set: $choicesCount to 1)]
-	(else:)[(set: $choicesCount to it + 1)]
-	(set: $cyclingResult to $choices's $choicesCount)
-	(link: (text: $choices's $choicesCount) )[(display: "Cycling")]
+	(link: (text: $choices's 1st) )[
+		(set: $choices to (rotated: -1, ...$choices))
+		(replace: ?choice)[(display: "Cycling")]
+	]
 }
 
 :: Results
-$cyclingResult
+Selected choice: (print: $choices's 1st)


### PR DESCRIPTION
Changed to use the (rotate:) macro which allows the number of required story variables to be reduced thus reducing the storage space needed in both History and Saves.

Also changed to use a named hook plus (replace:) macro combination to protect against exceeding maximum DOM depth and the rendering slowdown of DOM which can occur if the end-user keeps selecting the related link.