### PR TITLE
Change Harlowe and Snowman versions of Clamping not to use ES6 features

### DIFF
--- a/clamping_numbers/harlowe/harlowe_clamping_numbers.md
+++ b/clamping_numbers/harlowe/harlowe_clamping_numbers.md
@@ -48,11 +48,13 @@ Limiting the range of a number in Harlowe
 				throw new Error('Number.prototype.clamp called with an incorrect number of parameters');
 			}
 
-			let min = Number(arguments[0]);
-			let max = Number(arguments[1]);
+			var min = Number(arguments[0]);
+			var max = Number(arguments[1]);
 
 			if (min > max) {
-				[min, max] = [max, min];
+				var tmp = min;
+				min = max;
+				max = tmp;
 			}
 
 			return Math.min(Math.max(this, min), max);
@@ -75,7 +77,7 @@ Limiting the range of a number in Harlowe
 		writable     : true,
 
 		value(num, min, max) {
-			const value = Number(num);
+			var value = Number(num);
 			return Number.isNaN(value) ? NaN : value.clamp(min, max);
 		}
 	});

--- a/clamping_numbers/harlowe/harlowe_clamping_numbers_example.html
+++ b/clamping_numbers/harlowe/harlowe_clamping_numbers_example.html
@@ -11,7 +11,7 @@
 
 <tw-story></tw-story>
 
-<tw-storydata name="Limiting the range of a number in Harlowe" startnode="1" creator="Tweego" creator-version="1.3.0" ifid="4741F649-1834-401E-A70E-F4CDE71EFF00" zoom="1" format="Harlowe" format-version="2.0.1" options="" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css"></style><script role="script" id="twine-user-script" type="text/twine-javascript">/* twine-user-script #1: "UserScript" */
+<tw-storydata name="Limiting the range of a number in Harlowe" startnode="1" creator="Tweego" creator-version="1.3.0" ifid="DA902A47-828B-40DD-8C99-638C99DAE883" zoom="1" format="Harlowe" format-version="2.0.1" options="" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css"></style><script role="script" id="twine-user-script" type="text/twine-javascript">/* twine-user-script #1: "UserScript" */
 (function () {
 
 	/*
@@ -34,11 +34,13 @@
 				throw new Error('Number.prototype.clamp called with an incorrect number of parameters');
 			}
 
-			let min = Number(arguments[0]);
-			let max = Number(arguments[1]);
+			var min = Number(arguments[0]);
+			var max = Number(arguments[1]);
 
 			if (min > max) {
-				[min, max] = [max, min];
+				var tmp = min;
+				min = max;
+				max = tmp;
 			}
 
 			return Math.min(Math.max(this, min), max);
@@ -61,7 +63,7 @@
 		writable     : true,
 
 		value(num, min, max) {
-			const value = Number(num);
+			var value = Number(num);
 			return Number.isNaN(value) ? NaN : value.clamp(min, max);
 		}
 	});

--- a/clamping_numbers/harlowe/harlowe_clamping_numbers_twee.txt
+++ b/clamping_numbers/harlowe/harlowe_clamping_numbers_twee.txt
@@ -25,11 +25,13 @@ Limiting the range of a number in Harlowe
 				throw new Error('Number.prototype.clamp called with an incorrect number of parameters');
 			}
 
-			let min = Number(arguments[0]);
-			let max = Number(arguments[1]);
+			var min = Number(arguments[0]);
+			var max = Number(arguments[1]);
 
 			if (min > max) {
-				[min, max] = [max, min];
+				var tmp = min;
+				min = max;
+				max = tmp;
 			}
 
 			return Math.min(Math.max(this, min), max);
@@ -52,7 +54,7 @@ Limiting the range of a number in Harlowe
 		writable     : true,
 
 		value(num, min, max) {
-			const value = Number(num);
+			var value = Number(num);
 			return Number.isNaN(value) ? NaN : value.clamp(min, max);
 		}
 	});

--- a/clamping_numbers/snowman/snowman_clamping_numbers.md
+++ b/clamping_numbers/snowman/snowman_clamping_numbers.md
@@ -46,11 +46,13 @@ Limiting the range of a number in Snowman
 				throw new Error('Number.prototype.clamp called with an incorrect number of parameters');
 			}
 
-			let min = Number(arguments[0]);
-			let max = Number(arguments[1]);
+			var min = Number(arguments[0]);
+			var max = Number(arguments[1]);
 
 			if (min > max) {
-				[min, max] = [max, min];
+				var tmp = min;
+				min = max;
+				max = tmp;
 			}
 
 			return Math.min(Math.max(this, min), max);
@@ -73,7 +75,7 @@ Limiting the range of a number in Snowman
 		writable     : true,
 
 		value(num, min, max) {
-			const value = Number(num);
+			var value = Number(num);
 			return Number.isNaN(value) ? NaN : value.clamp(min, max);
 		}
 	});

--- a/clamping_numbers/snowman/snowman_clamping_numbers_example.html
+++ b/clamping_numbers/snowman/snowman_clamping_numbers_example.html
@@ -10,7 +10,7 @@ Limiting the range of a number in Snowman
 <body>
 <div id="passage"></div>
 
-<tw-storydata name="Limiting the range of a number in Snowman" startnode="1" creator="Tweego" creator-version="1.3.0" ifid="8CD60205-CDC1-477E-9A24-C634F6E48038" zoom="1" format="Snowman" format-version="1.3.0" options="" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css"></style><script role="script" id="twine-user-script" type="text/twine-javascript">/* twine-user-script #1: "UserScript" */
+<tw-storydata name="Limiting the range of a number in Snowman" startnode="1" creator="Tweego" creator-version="1.3.0" ifid="6D0AC2B2-81E4-411C-A9F5-0BE7AFC5545C" zoom="1" format="Snowman" format-version="1.3.0" options="" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css"></style><script role="script" id="twine-user-script" type="text/twine-javascript">/* twine-user-script #1: "UserScript" */
 (function () {
 
 	/*
@@ -33,11 +33,13 @@ Limiting the range of a number in Snowman
 				throw new Error('Number.prototype.clamp called with an incorrect number of parameters');
 			}
 
-			let min = Number(arguments[0]);
-			let max = Number(arguments[1]);
+			var min = Number(arguments[0]);
+			var max = Number(arguments[1]);
 
 			if (min > max) {
-				[min, max] = [max, min];
+				var tmp = min;
+				min = max;
+				max = tmp;
 			}
 
 			return Math.min(Math.max(this, min), max);
@@ -60,7 +62,7 @@ Limiting the range of a number in Snowman
 		writable     : true,
 
 		value(num, min, max) {
-			const value = Number(num);
+			var value = Number(num);
 			return Number.isNaN(value) ? NaN : value.clamp(min, max);
 		}
 	});

--- a/clamping_numbers/snowman/snowman_clamping_numbers_twee.txt
+++ b/clamping_numbers/snowman/snowman_clamping_numbers_twee.txt
@@ -25,11 +25,13 @@ Limiting the range of a number in Snowman
 				throw new Error('Number.prototype.clamp called with an incorrect number of parameters');
 			}
 
-			let min = Number(arguments[0]);
-			let max = Number(arguments[1]);
+			var min = Number(arguments[0]);
+			var max = Number(arguments[1]);
 
 			if (min > max) {
-				[min, max] = [max, min];
+				var tmp = min;
+				min = max;
+				max = tmp;
 			}
 
 			return Math.min(Math.max(this, min), max);
@@ -52,7 +54,7 @@ Limiting the range of a number in Snowman
 		writable     : true,
 
 		value(num, min, max) {
-			const value = Number(num);
+			var value = Number(num);
 			return Number.isNaN(value) ? NaN : value.clamp(min, max);
 		}
 	});


### PR DESCRIPTION
It was pointed out to me that I incorrectly left ES6 features (like let and const) in the Javascript code, this patch fixes that issue.