### PR TITLE
Fixed issues in Harlowe implementation of Dungeon Moving

### DIFF
--- a/dungeonmoving/harlowe/harlowe_dungeonmoving.md
+++ b/dungeonmoving/harlowe/harlowe_dungeonmoving.md
@@ -4,7 +4,7 @@
 
 "Moving through a 'dungeon'" uses the <a href="https://twine2.neocities.org/#macro_a">(array:)</a> macro to create a multidimensional array. Movement positions are then tracked through X and Y variables for a grid system. Each movement subtracts or adds to its cooresponding X or Y position and is compared to those same positions within the array. Different directions are shown if movement is possible in that direction.
 
-A map of the array is created through using temporary variables and building a HTML table by iterating through the it and placing different symbols matching walls, movement spaces, and the player herself.
+A map of the array is created by iterating through temporary variables and placing different symbols matching walls, movement spaces, and the player herself.
 
 ## Live Example
 
@@ -21,93 +21,127 @@ Download: <a href="harlowe_dungeonmoving_example.html" target="_blank">Live Exam
 :: StoryTitle
 Harlowe: Moving through Dungeons
 
+
+:: User Style [stylesheet]
+tw-include[type="startup"], tw-hook[name="workarea"] {
+	display: none;
+}
+tw-hook[name="map"] {
+    font-family: monospace; 
+	line-height: 1.75;
+	font-size: 16pt;
+}
+
+
 :: Start
 |map>[(display: "Map")]
-|=
-(link-repeat: "Up")[{
-	(set: _row to $dungeon's ($positionX) )
-	(if: _row's ($positionY - 1) is not 1)[
-		(set: $positionY to it - 1)
-	]
-	(replace: ?map)[(display: "Map")]
-}]
-=|=
-(link-repeat: "Left")[{
-	(set: _row to $dungeon's ($positionX) )
-	(if: _row's ($positionX - 1) is not 1)[
-		(set: $positionX to it - 1)
-	]
-	(replace: ?map)[(display: "Map")]
-}]
-=|=
-(link-repeat: "Right")[{
-	(set: _row to $dungeon's ($positionX) )
-	(if: _row's ($positionX + 1) is not 1)[
-		(set: $positionX to it + 1)
-	]
-	(replace: ?map)[(display: "Map")]
-}]
-=|=
-(link-repeat: "Down")[{
-	(set: _row to $dungeon's ($positionX) )
-	(if: _row's ($positionY + 1) is not 1)[
-		(set: $positionY to it + 1)
-	]
-	(replace: ?map)[(display: "Map")]
-}]
 
-|==|
 
 :: Map
-{
-	(set: $dungeonTable to "<table>")
-
-	(set: $i to 0)
-	
-	(for: each _row, ...$dungeon) [
-		
-		(set: $i to it + 1)
-		
-		(set: $dungeonTable to it + "<tr>")
-		
-		(set: $j to 0)
-		
-		(for: each _col, ..._row) [
-			
-			(set: $j to it + 1)
-			
-			(if: $i is $positionY and $j is $positionX)[
-				(set: $dungeonTable to it + "<td>P</td>")
+(set: $map to "")\
+|workarea>[
+	(for: each _y, ...(range: 1, $dungeon's length))[
+		(for: each _x, ...(range: 1, $dungeon's (_y)'s length))[
+			(if: _x is $positionX and _y is $positionY)[
+				(set: $map to it + "P ")
 			]
-			(else:) [
-				(if: _col is 0) [
-					(set: $dungeonTable to it + "<td>.</td>")
-				]
+			(else-if: $dungeon's (_y)'s (_x) is 0)[
+				(set: $map to it + "&num; ")
 			]
-			
-			(if: _col is 1)[
-				(set: $dungeonTable to it + "<td>#</td>")
+			(else-if: $dungeon's (_y)'s (_x) is 1)[
+				(set: $map to it + ". ")
+			]
+			(else-if: $dungeon's (_y)'s (_x) is 2)[
+				(set: $map to it + "E ")
 			]
 		]
-		
-		(set: $dungeonTable to it + "</tr>")
+		(set: $map to it + " <br>")
 	]
-	
-	(set: $dungeonTable to it + "</table>")
+]\
+$map
 
-	$dungeonTable
+{
+	(set: $seperator to "")\
+	(set: _north to $dungeon's ($positionY - 1)'s ($positionX))
+	(set: _east to $dungeon's ($positionY)'s ($positionX + 1))
+	(set: _south to $dungeon's ($positionY + 1)'s ($positionX))
+	(set: _west to $dungeon's ($positionY)'s ($positionX - 1))
+
+	(if: _north is 1)[
+		$seperator
+		(link: "North")[
+			(set: $positionY to it - 1)
+			(replace: ?map)[(display: "Map")]
+		]
+		(set: $seperator to " | ")
+	]
+	(else-if: _north is 2)[
+		$seperator[[Exit]]
+		(set: $seperator to " | ")
+	]
+
+	(if: _east is 1)[
+		$seperator
+		(link: "East")[
+			(set: $positionX to it + 1)
+			(replace: ?map)[(display: "Map")]
+		]
+		(set: $seperator to " | ")
+	]
+	(else-if: _east is 2)[
+		$seperator[[Exit]]
+		(set: $seperator to " | ")
+	]
+
+	(if: _south is 1)[
+		$seperator
+		(link: "South")[
+			(set: $positionY to it + 1)
+			(replace: ?map)[(display: "Map")]
+		]
+		(set: $seperator to " | ")
+	]
+	(else-if: _south is 2)[
+		$seperator[[Exit]]
+		(set: $seperator to " | ")
+	]
+
+	(if: _west is 1)[
+		$seperator
+		(link: "West")[
+			(set: $positionX to it - 1)
+			(replace: ?map)[(display: "Map")]
+		]
+	]
+	(else-if: _west is 2)[
+		$seperator[[Exit]]
+	]
 }
 
-:: Startup[startup]
+
+:: Startup [startup]
 {	
-	(set: $dungeon to (array: (a: 1,1,1,1,1),
-							  (a: 1,0,0,0,1),
-							  (a: 1,0,0,0,1),
-							  (a: 1,0,0,0,1),
-							  (a: 1,1,1,1,1) ) )
-	(set: $positionX to 2)
-	(set: $positionY to 2)
+	(set: $dungeon to (array: 
+			(a: 0,0,0,0,0,0,0,0,0,0,0),
+			(a: 0,1,1,1,0,1,1,1,1,1,0),
+			(a: 0,0,0,1,0,0,0,0,0,1,0),
+			(a: 0,1,0,1,1,1,1,1,0,1,0),
+			(a: 0,1,0,0,0,0,0,1,0,1,0),
+			(a: 0,1,1,1,1,1,1,1,0,1,0),
+			(a: 0,0,0,0,0,0,0,1,0,1,0),
+			(a: 0,1,0,1,1,1,1,1,1,1,0),
+			(a: 0,1,0,1,0,0,0,1,0,0,0),
+			(a: 0,1,1,1,0,1,1,1,1,2,0),
+			(a: 0,0,0,0,0,0,0,0,0,0,0)
+		)
+	)
+    (set: $positionX to 2)
+    (set: $positionY to 2)
 }
+
+
+:: Exit
+You have exited the map.
 ```
 
 Download: <a href="harlowe_dungeonmoving_twee.txt" target="_blank">Twee Code</a>

--- a/dungeonmoving/harlowe/harlowe_dungeonmoving_example.html
+++ b/dungeonmoving/harlowe/harlowe_dungeonmoving_example.html
@@ -11,85 +11,109 @@
 
 <tw-story></tw-story>
 
-<tw-storydata name="Harlowe: Moving through Dungeons" startnode="1" creator="Twine" creator-version="2.1.3" ifid="230D351F-C9B1-4428-929A-364479A4FBB9" format="Harlowe" format-version="2.0.1" options="" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css"></style><script role="script" id="twine-user-script" type="text/twine-javascript"></script><tw-passagedata pid="1" name="Start" tags="" position="104,100">|map&gt;[(display: &quot;Map&quot;)]
-|=
-(link-repeat: &quot;Up&quot;)[{
-	(set: _row to $dungeon&#x27;s ($positionX) )
-	(if: _row&#x27;s ($positionY - 1) is not 1)[
-		(set: $positionY to it - 1)
-	]
-	(replace: ?map)[(display: &quot;Map&quot;)]
-}]
-=|=
-(link-repeat: &quot;Left&quot;)[{
-	(set: _row to $dungeon&#x27;s ($positionX) )
-	(if: _row&#x27;s ($positionX - 1) is not 1)[
-		(set: $positionX to it - 1)
-	]
-	(replace: ?map)[(display: &quot;Map&quot;)]
-}]
-=|=
-(link-repeat: &quot;Right&quot;)[{
-	(set: _row to $dungeon&#x27;s ($positionX) )
-	(if: _row&#x27;s ($positionX + 1) is not 1)[
-		(set: $positionX to it + 1)
-	]
-	(replace: ?map)[(display: &quot;Map&quot;)]
-}]
-=|=
-(link-repeat: &quot;Down&quot;)[{
-	(set: _row to $dungeon&#x27;s ($positionX) )
-	(if: _row&#x27;s ($positionY + 1) is not 1)[
-		(set: $positionY to it + 1)
-	]
-	(replace: ?map)[(display: &quot;Map&quot;)]
-}]
-
-|==|</tw-passagedata><tw-passagedata pid="2" name="Map" tags="" position="302,99">{
-	(set: $dungeonTable to &quot;&lt;table&gt;&quot;)
-
-	(set: $i to 0)
-	
-	(for: each _row, ...$dungeon) [
-		
-		(set: $i to it + 1)
-		
-		(set: $dungeonTable to it + &quot;&lt;tr&gt;&quot;)
-		
-		(set: $j to 0)
-		
-		(for: each _col, ..._row) [
-			
-			(set: $j to it + 1)
-			
-			(if: $i is $positionY and $j is $positionX)[
-				(set: $dungeonTable to it + &quot;&lt;td&gt;P&lt;/td&gt;&quot;)
+<tw-storydata name="Harlowe: Moving through Dungeons" startnode="1" creator="Tweego" creator-version="1.3.0" ifid="4405ED7F-BFEB-4DF0-93C3-1C061FDEE6EA" zoom="1" format="Harlowe" format-version="2.0.1" options="" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">/* twine-user-stylesheet #1: "User Style" */
+tw-include[type="startup"], tw-hook[name="workarea"] {
+	display: none;
+}
+tw-hook[name="map"] {
+    font-family: monospace; 
+	line-height: 1.75;
+	font-size: 16pt;
+}</style><script role="script" id="twine-user-script" type="text/twine-javascript"></script><tw-passagedata pid="1" name="Start" tags="" position="100,100">|map&gt;[(display: &quot;Map&quot;)]</tw-passagedata><tw-passagedata pid="2" name="Map" tags="" position="225,100">(set: $map to &quot;&quot;)\
+|workarea&gt;[
+	(for: each _y, ...(range: 1, $dungeon&#39;s length))[
+		(for: each _x, ...(range: 1, $dungeon&#39;s (_y)&#39;s length))[
+			(if: _x is $positionX and _y is $positionY)[
+				(set: $map to it + &quot;P &quot;)
 			]
-			(else:) [
-				(if: _col is 0) [
-					(set: $dungeonTable to it + &quot;&lt;td&gt;.&lt;/td&gt;&quot;)
-				]
+			(else-if: $dungeon&#39;s (_y)&#39;s (_x) is 0)[
+				(set: $map to it + &quot;&amp;num; &quot;)
 			]
-			
-			(if: _col is 1)[
-				(set: $dungeonTable to it + &quot;&lt;td&gt;#&lt;/td&gt;&quot;)
+			(else-if: $dungeon&#39;s (_y)&#39;s (_x) is 1)[
+				(set: $map to it + &quot;. &quot;)
+			]
+			(else-if: $dungeon&#39;s (_y)&#39;s (_x) is 2)[
+				(set: $map to it + &quot;E &quot;)
 			]
 		]
-		
-		(set: $dungeonTable to it + &quot;&lt;/tr&gt;&quot;)
+		(set: $map to it + &quot; &lt;br&gt;&quot;)
 	]
-	
-	(set: $dungeonTable to it + &quot;&lt;/table&gt;&quot;)
+]\
+$map
 
-	$dungeonTable
-}</tw-passagedata><tw-passagedata pid="3" name="Startup" tags="startup" position="202,223">{	
-	(set: $dungeon to (array: (a: 1,1,1,1,1),
-							  (a: 1,0,0,0,1),
-							  (a: 1,0,0,0,1),
-							  (a: 1,0,0,0,1),
-							  (a: 1,1,1,1,1) ) )
-	(set: $positionX to 2)
-	(set: $positionY to 2)
+{
+	(set: $seperator to &quot;&quot;)\
+	(set: _north to $dungeon&#39;s ($positionY - 1)&#39;s ($positionX))
+	(set: _east to $dungeon&#39;s ($positionY)&#39;s ($positionX + 1))
+	(set: _south to $dungeon&#39;s ($positionY + 1)&#39;s ($positionX))
+	(set: _west to $dungeon&#39;s ($positionY)&#39;s ($positionX - 1))
+
+	(if: _north is 1)[
+		$seperator
+		(link: &quot;North&quot;)[
+			(set: $positionY to it - 1)
+			(replace: ?map)[(display: &quot;Map&quot;)]
+		]
+		(set: $seperator to &quot; | &quot;)
+	]
+	(else-if: _north is 2)[
+		$seperator[[Exit]]
+		(set: $seperator to &quot; | &quot;)
+	]
+
+	(if: _east is 1)[
+		$seperator
+		(link: &quot;East&quot;)[
+			(set: $positionX to it + 1)
+			(replace: ?map)[(display: &quot;Map&quot;)]
+		]
+		(set: $seperator to &quot; | &quot;)
+	]
+	(else-if: _east is 2)[
+		$seperator[[Exit]]
+		(set: $seperator to &quot; | &quot;)
+	]
+
+	(if: _south is 1)[
+		$seperator
+		(link: &quot;South&quot;)[
+			(set: $positionY to it + 1)
+			(replace: ?map)[(display: &quot;Map&quot;)]
+		]
+		(set: $seperator to &quot; | &quot;)
+	]
+	(else-if: _south is 2)[
+		$seperator[[Exit]]
+		(set: $seperator to &quot; | &quot;)
+	]
+
+	(if: _west is 1)[
+		$seperator
+		(link: &quot;West&quot;)[
+			(set: $positionX to it - 1)
+			(replace: ?map)[(display: &quot;Map&quot;)]
+		]
+	]
+	(else-if: _west is 2)[
+		$seperator[[Exit]]
+	]
+}</tw-passagedata><tw-passagedata pid="3" name="Startup" tags="startup" position="350,100">{	
+	(set: $dungeon to (array: 
+			(a: 0,0,0,0,0,0,0,0,0,0,0),
+			(a: 0,1,1,1,0,1,1,1,1,1,0),
+			(a: 0,0,0,1,0,0,0,0,0,1,0),
+			(a: 0,1,0,1,1,1,1,1,0,1,0),
+			(a: 0,1,0,0,0,0,0,1,0,1,0),
+			(a: 0,1,1,1,1,1,1,1,0,1,0),
+			(a: 0,0,0,0,0,0,0,1,0,1,0),
+			(a: 0,1,0,1,1,1,1,1,1,1,0),
+			(a: 0,1,0,1,0,0,0,1,0,0,0),
+			(a: 0,1,1,1,0,1,1,1,1,2,0),
+			(a: 0,0,0,0,0,0,0,0,0,0,0)
+		)
+	)
+    (set: $positionX to 2)
+    (set: $positionY to 2)
 }</tw-passagedata></tw-storydata>
 
 <script title="Twine engine code" data-main="harlowe">"use strict";function _defineProperty(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}function _toConsumableArray(e){if(Array.isArray(e)){for(var t=0,n=Array(e.length);t<e.length;t++)n[t]=e[t];return n}return Array.from(e)}var _slicedToArray=function(){function e(e,t){var n=[],r=!0,i=!1,o=void 0;try{for(var a,s=e[Symbol.iterator]();!(r=(a=s.next()).done)&&(n.push(a.value),!t||n.length!==t);r=!0);}catch(e){i=!0,o=e}finally{try{!r&&s.return&&s.return()}finally{if(i)throw o}}return n}return function(t,n){if(Array.isArray(t))return t;if(Symbol.iterator in Object(t))return e(t,n);throw new TypeError("Invalid attempt to destructure non-iterable instance")}}(),_typeof="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e};!function(){/**

--- a/dungeonmoving/harlowe/harlowe_dungeonmoving_twee.txt
+++ b/dungeonmoving/harlowe/harlowe_dungeonmoving_twee.txt
@@ -1,90 +1,124 @@
 :: StoryTitle
 Harlowe: Moving through Dungeons
 
+
+:: User Style [stylesheet]
+tw-include[type="startup"], tw-hook[name="workarea"] {
+	display: none;
+}
+tw-hook[name="map"] {
+    font-family: monospace; 
+	line-height: 1.75;
+	font-size: 16pt;
+}
+
+
 :: Start
 |map>[(display: "Map")]
-|=
-(link-repeat: "Up")[{
-	(set: _row to $dungeon's ($positionX) )
-	(if: _row's ($positionY - 1) is not 1)[
-		(set: $positionY to it - 1)
-	]
-	(replace: ?map)[(display: "Map")]
-}]
-=|=
-(link-repeat: "Left")[{
-	(set: _row to $dungeon's ($positionX) )
-	(if: _row's ($positionX - 1) is not 1)[
-		(set: $positionX to it - 1)
-	]
-	(replace: ?map)[(display: "Map")]
-}]
-=|=
-(link-repeat: "Right")[{
-	(set: _row to $dungeon's ($positionX) )
-	(if: _row's ($positionX + 1) is not 1)[
-		(set: $positionX to it + 1)
-	]
-	(replace: ?map)[(display: "Map")]
-}]
-=|=
-(link-repeat: "Down")[{
-	(set: _row to $dungeon's ($positionX) )
-	(if: _row's ($positionY + 1) is not 1)[
-		(set: $positionY to it + 1)
-	]
-	(replace: ?map)[(display: "Map")]
-}]
 
-|==|
 
 :: Map
-{
-	(set: $dungeonTable to "<table>")
-
-	(set: $i to 0)
-	
-	(for: each _row, ...$dungeon) [
-		
-		(set: $i to it + 1)
-		
-		(set: $dungeonTable to it + "<tr>")
-		
-		(set: $j to 0)
-		
-		(for: each _col, ..._row) [
-			
-			(set: $j to it + 1)
-			
-			(if: $i is $positionY and $j is $positionX)[
-				(set: $dungeonTable to it + "<td>P</td>")
+(set: $map to "")\
+|workarea>[
+	(for: each _y, ...(range: 1, $dungeon's length))[
+		(for: each _x, ...(range: 1, $dungeon's (_y)'s length))[
+			(if: _x is $positionX and _y is $positionY)[
+				(set: $map to it + "P ")
 			]
-			(else:) [
-				(if: _col is 0) [
-					(set: $dungeonTable to it + "<td>.</td>")
-				]
+			(else-if: $dungeon's (_y)'s (_x) is 0)[
+				(set: $map to it + "&num; ")
 			]
-			
-			(if: _col is 1)[
-				(set: $dungeonTable to it + "<td>#</td>")
+			(else-if: $dungeon's (_y)'s (_x) is 1)[
+				(set: $map to it + ". ")
+			]
+			(else-if: $dungeon's (_y)'s (_x) is 2)[
+				(set: $map to it + "E ")
 			]
 		]
-		
-		(set: $dungeonTable to it + "</tr>")
+		(set: $map to it + " <br>")
 	]
-	
-	(set: $dungeonTable to it + "</table>")
+]\
+$map
 
-	$dungeonTable
+{
+	(set: $seperator to "")\
+	(set: _north to $dungeon's ($positionY - 1)'s ($positionX))
+	(set: _east to $dungeon's ($positionY)'s ($positionX + 1))
+	(set: _south to $dungeon's ($positionY + 1)'s ($positionX))
+	(set: _west to $dungeon's ($positionY)'s ($positionX - 1))
+
+	(if: _north is 1)[
+		$seperator
+		(link: "North")[
+			(set: $positionY to it - 1)
+			(replace: ?map)[(display: "Map")]
+		]
+		(set: $seperator to " | ")
+	]
+	(else-if: _north is 2)[
+		$seperator[[Exit]]
+		(set: $seperator to " | ")
+	]
+
+	(if: _east is 1)[
+		$seperator
+		(link: "East")[
+			(set: $positionX to it + 1)
+			(replace: ?map)[(display: "Map")]
+		]
+		(set: $seperator to " | ")
+	]
+	(else-if: _east is 2)[
+		$seperator[[Exit]]
+		(set: $seperator to " | ")
+	]
+
+	(if: _south is 1)[
+		$seperator
+		(link: "South")[
+			(set: $positionY to it + 1)
+			(replace: ?map)[(display: "Map")]
+		]
+		(set: $seperator to " | ")
+	]
+	(else-if: _south is 2)[
+		$seperator[[Exit]]
+		(set: $seperator to " | ")
+	]
+
+	(if: _west is 1)[
+		$seperator
+		(link: "West")[
+			(set: $positionX to it - 1)
+			(replace: ?map)[(display: "Map")]
+		]
+	]
+	(else-if: _west is 2)[
+		$seperator[[Exit]]
+	]
 }
 
-:: Startup[startup]
+
+:: Startup [startup]
 {	
-	(set: $dungeon to (array: (a: 1,1,1,1,1),
-							  (a: 1,0,0,0,1),
-							  (a: 1,0,0,0,1),
-							  (a: 1,0,0,0,1),
-							  (a: 1,1,1,1,1) ) )
-	(set: $positionX to 2)
-	(set: $positionY to 2)
+	(set: $dungeon to (array: 
+			(a: 0,0,0,0,0,0,0,0,0,0,0),
+			(a: 0,1,1,1,0,1,1,1,1,1,0),
+			(a: 0,0,0,1,0,0,0,0,0,1,0),
+			(a: 0,1,0,1,1,1,1,1,0,1,0),
+			(a: 0,1,0,0,0,0,0,1,0,1,0),
+			(a: 0,1,1,1,1,1,1,1,0,1,0),
+			(a: 0,0,0,0,0,0,0,1,0,1,0),
+			(a: 0,1,0,1,1,1,1,1,1,1,0),
+			(a: 0,1,0,1,0,0,0,1,0,0,0),
+			(a: 0,1,1,1,0,1,1,1,1,2,0),
+			(a: 0,0,0,0,0,0,0,0,0,0,0)
+		)
+	)
+    (set: $positionX to 2)
+    (set: $positionY to 2)
 }
+
+
+:: Exit
+You have exited the map.


### PR DESCRIPTION
The original links where checking the wrong row / column / both when determining if movement in the relevant direction was possible, this became apparent when a user tried to make a more complex map like that in the SugarCube implementation. I have updated the included map and fixes the X/Y issue, I also made the links conditional based on movement possibility and added support for an Exit like the other implementations.

The table element injecting can be quite slow (one end-user complained the delay was over 5 seconds per link selection), so I replaced it with the injection of a br element separated character String.