### PR TITLE
Latest release notes with "Release Date" added

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -359,6 +359,16 @@ nav:
           - 'Common Questions': 'twine1/storyformats/sugarcane/questions.md'
   - Release Notes Archive:
       - Twine 2:
+        - '2.6.2': 'releasenotes/twine2/2.6.2.md'
+        - '2.6.1': 'releasenotes/twine2/2.6.1.md'
+        - '2.6.0': 'releasenotes/twine2/2.6.0.md'
+        - '2.5.1': 'releasenotes/twine2/2.5.1.md'
+        - '2.5.0': 'releasenotes/twine2/2.5.0.md'
+        - '2.4.1': 'releasenotes/twine2/2.4.1.md'
+        - '2.4.0': 'releasenotes/twine2/2.4.0.md'
+        - '2.3.16': 'releasenotes/twine2/2.3.16.md'
+        - '2.3.15': 'releasenotes/twine2/2.3.15.md'
+        - '2.3.14': 'releasenotes/twine2/2.3.14.md'
         - '2.3.13': 'releasenotes/twine2/2.3.13.md'
         - '2.3.12': 'releasenotes/twine2/2.3.12.md'
         - '2.3.11': 'releasenotes/twine2/2.3.11.md'

--- a/pages/releasenotes/twine2/2.0.10.md
+++ b/pages/releasenotes/twine2/2.0.10.md
@@ -1,3 +1,7 @@
 # Twine 2.0.10
 
+Release Date: Nov 20, 2015
+
+## Editor
+
 Twine 2.0.10 has the same changelog as 2.0.9, but it includes Harlowe 1.2.1, which fixes a problem with `(else:)` invocations.

--- a/pages/releasenotes/twine2/2.0.11.md
+++ b/pages/releasenotes/twine2/2.0.11.md
@@ -1,5 +1,7 @@
 # Twine 2.0.11
 
+Release Date: Feb 27, 2016
+
 ## Features added
 
 - Includes new localizations for German and Finnish.

--- a/pages/releasenotes/twine2/2.0.4.md
+++ b/pages/releasenotes/twine2/2.0.4.md
@@ -1,5 +1,7 @@
 # Twine 2.0.4
 
+Release Date: Apr 12, 2015
+
 ## Editor
 
 ### Bugfixes

--- a/pages/releasenotes/twine2/2.0.5.md
+++ b/pages/releasenotes/twine2/2.0.5.md
@@ -1,5 +1,7 @@
 # Twine 2.0.5
 
+Release Date: May 26, 2015
+
 ## Editor
 
 This is the first release in the 2.x series to offer native apps for desktop OSes.

--- a/pages/releasenotes/twine2/2.0.6.md
+++ b/pages/releasenotes/twine2/2.0.6.md
@@ -1,5 +1,7 @@
 # Twine 2.0.6
 
+Release Date: May 31, 2015
+
 ## Editor
 
 ### Bugfixes

--- a/pages/releasenotes/twine2/2.0.7.md
+++ b/pages/releasenotes/twine2/2.0.7.md
@@ -1,5 +1,7 @@
 # Twine 2.0.7
 
+Release Date: Jul 4, 2015
+
 ## Editor
 
 ### Features

--- a/pages/releasenotes/twine2/2.0.8.md
+++ b/pages/releasenotes/twine2/2.0.8.md
@@ -1,5 +1,7 @@
 # Twine 2.0.8
 
+Release Date: Jul 6, 2015
+
 ## Features added
 
 - Fixes bug where `<` and `>` characters would be garbled in stories in the native app version has been fixed.

--- a/pages/releasenotes/twine2/2.0.9.md
+++ b/pages/releasenotes/twine2/2.0.9.md
@@ -1,5 +1,7 @@
 # Twine 2.0.9
 
+Release Date: Nov 17, 2015
+
 ## Editor
 
 ### Features

--- a/pages/releasenotes/twine2/2.1.0.md
+++ b/pages/releasenotes/twine2/2.1.0.md
@@ -1,5 +1,7 @@
 # Twine 2.1.0
 
+Release Date: Jan 31, 2017
+
 ## Upgrade Notes
 
 This is a significant update from the 2.0 series. If you're upgrading, please read the notes below before beginning.

--- a/pages/releasenotes/twine2/2.1.1.md
+++ b/pages/releasenotes/twine2/2.1.1.md
@@ -1,5 +1,7 @@
 # Twine 2.1.1
 
+Release Date: Mar 1, 2017
+
 ## Features added
 
 - Added Czech, German, Italian, and Portuguese localizations.

--- a/pages/releasenotes/twine2/2.1.2.md
+++ b/pages/releasenotes/twine2/2.1.2.md
@@ -1,5 +1,7 @@
 # Twine 2.1.2
 
+Release Date: Apr 29, 2017
+
 If you are upgrading and using a non-English localization, this will cause your stories to be saved to a slightly different folder than before. Instead of Twine -\> Stories, they will now be saved to Twine -\> \[the word "Stories" as translated to your language\]. You will probably need to move your existing stories into this new folder.
 
 ## Features

--- a/pages/releasenotes/twine2/2.1.3.md
+++ b/pages/releasenotes/twine2/2.1.3.md
@@ -1,5 +1,7 @@
 # Twine 2.1.3
 
+Release Date: May 1, 2017
+
 ## Bugfixes
 
 - An issue causing passages to disappear, be positioned incorrectly, or otherwise become corrupted has been fixed.

--- a/pages/releasenotes/twine2/2.2.0.md
+++ b/pages/releasenotes/twine2/2.2.0.md
@@ -1,5 +1,7 @@
 # Twine 2.2.0
 
+Release Date: Dec 14, 2017
+
 ## Features
 
 - Passages can now be wide, tall, or just plain large.

--- a/pages/releasenotes/twine2/2.2.1.md
+++ b/pages/releasenotes/twine2/2.2.1.md
@@ -1,5 +1,7 @@
 # Twine 2.2.1
 
+Release Date: Dec 20, 2017
+
 ## Bugfixes
 
 - Last modified dates on stories in the desktop app are maintained correctly.

--- a/pages/releasenotes/twine2/2.3.0.md
+++ b/pages/releasenotes/twine2/2.3.0.md
@@ -1,5 +1,7 @@
 # Twine 2.3.0
 
+Release Date: Apr 14, 2019
+
 ## Features added
 
 - The desktop app now uses Electron instead of NW.js. This should resolve many crash issues, and also bring improved performance, as saving changes is now done on a separate processing thread than the main user interface.

--- a/pages/releasenotes/twine2/2.3.1.md
+++ b/pages/releasenotes/twine2/2.3.1.md
@@ -1,5 +1,7 @@
 # Twine 2.3.1
 
+Release Date: Apr 21, 2019
+
 ## Bugs fixed
 
 * In the desktop app, file saving is done in a safer manner so that if a problem occurs, any file that would have been overwritten should stay intact.

--- a/pages/releasenotes/twine2/2.3.10.md
+++ b/pages/releasenotes/twine2/2.3.10.md
@@ -1,5 +1,7 @@
 # Twine 2.3.10
 
+Release Date: Jan 3, 2021
+
 This is a maintenance release for Twine 2.3.
 
 ## Features added

--- a/pages/releasenotes/twine2/2.3.11.md
+++ b/pages/releasenotes/twine2/2.3.11.md
@@ -1,5 +1,7 @@
 # Twine 2.3.11
 
+Release Date: Jan 17, 2021
+
 This is a maintenance release for Twine 2.3.
 
 ## Features added

--- a/pages/releasenotes/twine2/2.3.12.md
+++ b/pages/releasenotes/twine2/2.3.12.md
@@ -1,5 +1,7 @@
 # Twine 2.3.12
 
+Release Date: Jan 24, 2021
+
 This is a maintenance release for Twine 2.3.
 
 ## Features added

--- a/pages/releasenotes/twine2/2.3.13.md
+++ b/pages/releasenotes/twine2/2.3.13.md
@@ -1,5 +1,7 @@
 # Twine 2.3.13
 
+Release Date: Feb 15, 2021
+
 This is a maintenance release for Twine 2.3.
 
 ## Features added

--- a/pages/releasenotes/twine2/2.3.14.md
+++ b/pages/releasenotes/twine2/2.3.14.md
@@ -1,0 +1,11 @@
+# Twine 2.3.14
+
+Release Date: May 11, 2021
+
+This is a maintenance release for Twine 2.3.
+
+## Features added
+
+Updated Harlowe to 3.2.2.
+Bugs fixed
+Removed a conflict between JavaScript polyfills provided by core-js and Harlowe.

--- a/pages/releasenotes/twine2/2.3.15.md
+++ b/pages/releasenotes/twine2/2.3.15.md
@@ -1,0 +1,9 @@
+# Twine 2.3.15
+
+Release Date: Oct 21, 2021
+
+This is a maintenance release for Twine 2.3.
+
+## Features added
+
+Updated Harlowe to 3.2.3.

--- a/pages/releasenotes/twine2/2.3.16.md
+++ b/pages/releasenotes/twine2/2.3.16.md
@@ -1,0 +1,9 @@
+# Twine 2.3.16
+
+Release Date: Jan 9, 2022
+
+This is a maintenance release for Twine 2.3.
+
+## Features added
+
+Updated SugarCube to 2.36.1.

--- a/pages/releasenotes/twine2/2.3.2.md
+++ b/pages/releasenotes/twine2/2.3.2.md
@@ -1,5 +1,7 @@
 # Twine 2.3.2
 
+Release Date: Jun 10, 2019
+
 ## Bugs fixed
 
 * Various issues related to playing and testing stories within Twine have been resolved. Twine now opens playable versions of stories in your default browser instead of inside Twine.

--- a/pages/releasenotes/twine2/2.3.3.md
+++ b/pages/releasenotes/twine2/2.3.3.md
@@ -1,5 +1,7 @@
 # Twine 2.3.3
 
+Release Date: Jul 22, 2019
+
 ## Bugs fixed
 
 * Proofing stories, broken in 2.3.2, is working again.

--- a/pages/releasenotes/twine2/2.3.4.md
+++ b/pages/releasenotes/twine2/2.3.4.md
@@ -1,5 +1,7 @@
 # Twine 2.3.4
 
+Release Date: Sep 22, 2019
+
 This is a maintenance release for Twine 2.3.
 
 ## Features added

--- a/pages/releasenotes/twine2/2.3.5.md
+++ b/pages/releasenotes/twine2/2.3.5.md
@@ -1,5 +1,7 @@
 # Twine 2.3.5
 
+Release Date: Oct 7, 2019
+
 This is a maintenance release for Twine 2.3.
 
 ## Features added

--- a/pages/releasenotes/twine2/2.3.6.md
+++ b/pages/releasenotes/twine2/2.3.6.md
@@ -1,3 +1,5 @@
 # Twine 2.3.6
 
+Release Date: Mar 30, 2020
+
 This release is only for the [web based version](https://twinery.org/2). It adds a warning for users of Safari 13.1 and beyond that their story library is at risk, and they should use a different platform. See [this Webkit blog post](https://webkit.org/blog/10218/full-third-party-cookie-blocking-and-more/) under the "7-Day Cap on All Script-Writeable Storage" heading for technical details.

--- a/pages/releasenotes/twine2/2.3.7.md
+++ b/pages/releasenotes/twine2/2.3.7.md
@@ -1,5 +1,7 @@
 # Twine 2.3.7
 
+Release Date: Apr 12, 2020
+
 This is a maintenance release for Twine 2.3.
 
 ## Features added

--- a/pages/releasenotes/twine2/2.3.8.md
+++ b/pages/releasenotes/twine2/2.3.8.md
@@ -1,5 +1,7 @@
 # Twine 2.3.8
 
+Release Date: May 10, 2020
+
 This is a maintenance release for Twine 2.3.
 
 ## Features added

--- a/pages/releasenotes/twine2/2.3.9.md
+++ b/pages/releasenotes/twine2/2.3.9.md
@@ -1,5 +1,7 @@
 # Twine 2.3.9
 
+Release Date: Jul 12, 2020
+
 This is a maintenance release for Twine 2.3.
 
 ## Features added

--- a/pages/releasenotes/twine2/2.4.0.md
+++ b/pages/releasenotes/twine2/2.4.0.md
@@ -1,0 +1,54 @@
+# Twine 2.4.0
+
+Release Date: Jul 5, 2022
+
+## General UI Updates
+
+There's now a toolbar that appears at the top of the screen for all actions. The toolbar's separated into tabs, similar to a menu bar, and has a back button allowing navigation between screens.
+
+The system font is used instead of a custom one. This is mostly an aesthetic change, but it also helps with non-Latin text.
+
+Some actions, like changing preferences or editing story formats, are available regardless of where you are in the app.
+
+The desktop app now has an ARM Linux build, and the macOS app is universal, running on both Intel and Apple Silicon processors natively.
+
+The desktop app has a new icon.
+
+## The Story List
+
+You now select a story from the list and then take an action on it using the toolbar instead of using a gear menu. Double-clicking a story will edit it.
+
+Stories can now be tagged, and the story list can be filtered to show only certain tags. Just like passage tags, story tags can have colors associated with them.
+
+Story previews have been updated to look hopefully nicer.
+
+## The Story Format List
+
+By default, only the most up-to-date version of a story format is shown in the list. You can see all installed formats using the View top toolbar tab.
+
+## The Story Map
+
+You can now undo and redo changes.
+
+You can now edit multiple passages at one time.
+
+You can rename a passage without editing it.
+
+You can now delete more than one passage at a time.
+
+All detail dialogs, like the find & replace text dialog, are now modeless, meaning that you can do other work in your story while they're open.
+
+You can customize the font used in passage editors and disable cursor blinking.
+
+Story formats now have an official way to extend the editor. (The Harlowe story format used undocumented methods to do this in the past.) Story formats can add syntax highlighting to passage editors, a toolbar of actions to passage editors, and add additional connections between passages in the map.
+
+- Right now, Harlowe and Chapbook have extensions but other story formats may add them in the future.
+- You can disable story format extensions if they are causing trouble or you prefer not to use them.
+- If you're a story format developer, learn how extensions work here.
+Editing larger stories is faster.
+
+## Story Formats
+
+Harlowe 3.3.0 is included, and release notes are here.
+
+Chapbook 1.2.2 is also included. It's the same as the last version, 1.2.1, except for the addition of editor extensions.

--- a/pages/releasenotes/twine2/2.4.1.md
+++ b/pages/releasenotes/twine2/2.4.1.md
@@ -1,0 +1,29 @@
+# Twine 2.4.1
+
+Release Date: Jul 13, 2022
+
+## New Features and Improvements
+
+The German localization has been improved (thanks @JimB16).
+Updated the version of Electron used for app Twine to the latest v17 release.
+
+## Bugs Fixed
+
+Fixed a bug related to updating stories' story formats. This showed up in 2.4.0 as a crash message the first time a story was edited.
+
+Browser Twine now uses the Storage Manager API to determine how much space is left for Twine to use. You may see a change in the value reported from previous versions, which estimated it by trying to save increasingly large amounts of data until it failed. This should fix error messages seen in 2.4.0 like `Failed to execute 'setItem' on 'Storage': Setting the value of 'twine-passages-abcdef-ghijklmn' exceeded the quota.`
+
+Backups work properly in app Twine.
+
+## Documentation
+
+- A section on how to switch to an older version of Twine has been added.
+- Small proofreading corrections (thanks @ChapelR).
+
+## Story Formats
+
+Harlowe is updated to 3.3.1. (changelog)
+
+## Known Issues
+
+Editing passage links, especially if you type [[ and ]] and then write a passage name, can create extraneous passages as you type, depending on how fast you type. An improvement on this behavior should come in the next feature release (there may be further bugfix releases before then).

--- a/pages/releasenotes/twine2/2.5.0.md
+++ b/pages/releasenotes/twine2/2.5.0.md
@@ -1,0 +1,37 @@
+# Twine 2.5.0
+
+Release Date: Aug 27, 2022
+
+## New Features and Improvements
+
+- Passages considered "empty" now show with a translucent background. To be considered empty, a passage must satisfy all of the criteria below:
+  - Has no text, not even just whitespace
+  - Has no tags
+  - Is the default size (small)
+  - Is not the start passage of the story
+- If the last link to an empty passage is removed, an empty passage will be deleted.
+  - This behavior is somewhat provisional, and constructive feedback is appreciated. The goal of this change is to address issues where typing links could create many extraneous passages, and to generally help keep stories from being cluttered with unused passages.
+- Dialogs may now be maximized.
+- The width of dialogs can now be customized in the Preferences dialog.
+- If playing, testing, or publishing a story to file fails, an error message is now shown. Previously, it failed silently.
+- The Delete Passages button now disables if the start passage in the story is selected.
+- Portuguese and French translations have been improved (thanks @albuquezi and @Kln95130).
+
+## Features Removed
+
+- Middle-clicking the story map no longer creates a passage. It falls back to the default behavior instead, usually allowing the user to scroll around the story map.
+
+## Bugs Fixed
+
+- Entering an invalid regular expression in the Find and Replace text no longer crashes Twine. It now reports no matches.
+- Replacing a story during an import now correctly links passages to their parent story. This bug manifested as an inability to select passages, edit them in some cases, and other similar problems.
+- Padding on the story map has been adjusted so that dialogs no longer overlap passages on the right.
+- If the list of story tags or stories to import is too long to fit the window height, the list scrolls properly.
+Portuguese and Chinese localizations now load correctly.
+- If an incorrect story format URL is entered when adding a new story format, an error is shown correctly. Previously, it showed placeholder text.
+- The Mac app is now ad hoc signed, so users on Apple Silicon should not see repeated permissions prompts when the app launches--only one, the first time it runs.
+- The app icon on Windows has been enlarged.
+
+## Story Format Updates
+
+Harlowe has been updated to 3.3.2.

--- a/pages/releasenotes/twine2/2.5.1.md
+++ b/pages/releasenotes/twine2/2.5.1.md
@@ -1,0 +1,7 @@
+# Twine 2.5.1
+
+Release Date: Aug 28, 2022
+
+## Story Format Updates
+
+Harlowe has been updated to 3.3.3.

--- a/pages/releasenotes/twine2/2.6.0.md
+++ b/pages/releasenotes/twine2/2.6.0.md
@@ -1,0 +1,27 @@
+# Twine 2.6.0
+
+Release Date: Jan 8, 2023
+
+This is likely to be the last app version of Twine for 32-bit Linux. Electron 18, which this release is based on, appears to be the last version of Electron to support 32-bit Linux, and it reached end-of-support in September 2022. Support for 64-bit Linux should not change.
+
+## New Features and Improvements
+
+- When a second passage edit dialog is opened after one is already open, the new dialog appears on top of the existing one, forming a stack. A passage edit dialog can be brought to the front by clicking its title bar. There is a maximum of 5 passage edit dialogs in the background; opening more will cause the lowest to be closed.
+- Twine can now import and export Twee files. Twee is a plain-text format used by many other tools in the Twine community, and has a tech spec. Twine exports to Twee 3 format and can import either Twee 3 or older versions.
+- Added a Go To button to the story map toolbar, which allows moving to a passage by name.
+- If there are no conflicts when importing a file, then Twine now automatically completes the import without asking for further confirmation.
+- If a dialog is already open when it would have normally been opened (like choosing to open Preferences twice), the existing dialog will animate to draw attention to itself, instead of nothing happening.
+- Added a Ukrainian localization, and updated the Chinese, German, and Turkish localizations.
+- The Mac app is now signed, thanks to the Interactive Fiction Technology Foundation. This means that running Twine on Macs no longer should require right-clicking it and choosing Open the first time it's downloaded.
+  - The relationship between Twine and IFTF has not changed. Although IFTF provides support for the Twine community, Twine itself is an entity independent of the IFTF.
+
+## Bugs Fixed
+
+- Fixed a problem where dragging the story map and moving the cursor outside the Twine window would cause inappropriate scrolling.
+- Fixed a broken link explaining what a story format is.
+- Fixed a bug with importing stories that were missing some attributes.
+- Fixed the appearance of passage edit dialogs that had been maximized, but also collapsed.
+
+## Story Format Updates
+
+Harlowe has been updated to version 3.3.4.

--- a/pages/releasenotes/twine2/2.6.1.md
+++ b/pages/releasenotes/twine2/2.6.1.md
@@ -1,0 +1,15 @@
+# Twine 2.6.1
+
+Release Notes: Feb 5, 2023
+
+## New Features Added
+
+The Dutch translation has been updated.
+
+## Bugs Fixed
+
+- Fixed a bug where passages would appear empty on the map when they weren't.
+- The Go To Passage dialog now receives mouse events properly.
+- Matches in the Find and Replace dialog should no longer flicker when other changes occur in a story.
+- The macOS app is now both signed and notarized, and should not require a right-click to open 🤞 .
+- Fixed a bug in Twee import where leading or trailing spaces in a passage name were not preserved.

--- a/pages/releasenotes/twine2/2.6.2.md
+++ b/pages/releasenotes/twine2/2.6.2.md
@@ -1,0 +1,12 @@
+# Twine 2.6.2
+
+Release Date: Feb 26, 2023
+
+## New Features Added
+
+- The "Start Story Here" checkbox in passage edit dialogs has been replaced with "Test from Here".
+
+## Story Format Updates
+
+- Chapbook has been updated to version 1.2.3.
+- Harlowe has been updated to version 3.3.5.


### PR DESCRIPTION
**Description:** 

The Cookbook does not have updated release notes for Twine 2 versions after the last major update in 2021. This adds versions 2.3.14 through 2.6.2.

This also adds a "Release Date" field for every version of Twine 2 starting from 2.0.4 through 2.6.2. While not something everyone would want or use, I have personally cited many versions of Twine using the Cookbook for multiple academic articles and in my doctoral dissertation. Having the release dates all in the same place would be *very* helpful for other academics wanting to cite Twine versions and the changes between them.

**Credit:** 

I'm already credited. I wrote most of the Cookbook.