### PR TITLE
Release notes for Twine 2.7 and Twine 2.7.1

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -359,6 +359,8 @@ nav:
           - 'Common Questions': 'twine1/storyformats/sugarcane/questions.md'
   - Release Notes Archive:
       - Twine 2:
+        - '2.7.1': 'releasenotes/twine2/2.7.1.md'
+        - '2.7.0': 'releasenotes/twine2/2.7.0.md'
         - '2.6.2': 'releasenotes/twine2/2.6.2.md'
         - '2.6.1': 'releasenotes/twine2/2.6.1.md'
         - '2.6.0': 'releasenotes/twine2/2.6.0.md'

--- a/pages/releasenotes/twine2/2.7.0.md
+++ b/pages/releasenotes/twine2/2.7.0.md
@@ -1,0 +1,19 @@
+# Twine 2.7.0
+
+Release Date: July 8, 2023
+
+## New Features Added
+
+Passage edit dialogs now show leading and trailing whitespace in passage names as `␣` symbols, to help tracking down accidental spaces.
+
+The app version of Twine now supports customizing its UI via a `user.css` file. More info on how this works is in the reference.
+
+The zoom controls in the story map have been moved into the top toolbar, so that the amount of space in the story map is increased.
+
+## Bugs Fixed
+
+JavaScript and CSS edit dialogs receive the right amount of vertical space when open in conjunction with passage editors.
+
+## Story Format Updates
+
+Harlowe has been updated to version 3.3.6.

--- a/pages/releasenotes/twine2/2.7.1.md
+++ b/pages/releasenotes/twine2/2.7.1.md
@@ -1,0 +1,11 @@
+# Twine 2.7.1
+
+Release Date: August 27, 2023
+
+## Bugs Fixed
+
+Fixed a bug where maximizing a passage editor made it disappear.
+
+## Story Format Updates
+
+Harlowe has been updated to version 3.3.7.


### PR DESCRIPTION
**Issue:** 

Keeping release notes updated.

**Description:** 

Adds release notes for Twine 2.7 and Twine 2.7.1

**Credit:** 

Already credited.